### PR TITLE
Favor const over let

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,9 +5,9 @@ export function style(sheet) {
       toggle = null;
     }
 
-    let missing = [];
-    let parts = query.split(' ');
-    let selectors = parts
+    const missing = [];
+    const parts = query.split(' ');
+    const selectors = parts
       .reduce((arr, selector) => {
         // Add conditional selector support
         selector = conditionalSelector(selector, toggle);
@@ -37,7 +37,7 @@ export function style(sheet) {
       .filter(style => style);
 
     // Compile props
-    let props = selectors
+    const props = selectors
       .reduce((props, selector) => {
         if (!sheet.props) return props;
 
@@ -85,7 +85,7 @@ export function pile(name, sheet, flattened = {}, props = {}) {
 };
 
 export default function(sheet = {}, stylesTransformer = noopTransformer) {
-  let stylesAndProps = pile(sheet);
+  const stylesAndProps = pile(sheet);
 
   // Allow the user a chance to convert the styles into a RN stylesheet
   stylesAndProps.styles = stylesTransformer(stylesAndProps.styles);
@@ -102,16 +102,16 @@ function makeName(...names) {
 }
 
 // The property names which can be styled via an object in RN
-let STYLE_RESERVED_WORDS = ['shadowOffset', 'props'];
+const STYLE_RESERVED_WORDS = ['shadowOffset', 'props'];
 
 function isNestedElement(attribute, value) {
   return STYLE_RESERVED_WORDS.indexOf(attribute) === -1 &&
-         value != null && 
-         !Array.isArray(value) && 
+         value != null &&
+         !Array.isArray(value) &&
          typeof value === 'object'
 }
 
-let PROPS_RESERVED_WORDS = ['styles'];
+const PROPS_RESERVED_WORDS = ['styles'];
 
 function isValidProps(props) {
   return Object.keys(props).reduce((cur, prop) => {
@@ -121,8 +121,8 @@ function isValidProps(props) {
 
 // If the selector is conditional, return it based on toggle
 function conditionalSelector(selector, toggle) {
-  let usingToggleHash = toggle != null && Object.keys(toggle).length !== 0;
-  let selectorParts = selector.split('?');
+  const usingToggleHash = toggle != null && Object.keys(toggle).length !== 0;
+  const selectorParts = selector.split('?');
 
   // The selector is conditional
   if (selectorParts.length > 1) {
@@ -142,10 +142,10 @@ function conditionalSelector(selector, toggle) {
 
 // Convert from "foo.bar.baz" to ["foo", "foo.bar", "foo.bar.baz"]
 function dotExpander(selector) {
-  let expanded = [];
+  const expanded = [];
   let base = '';
   selector.split('.').forEach(segment => {
-    let part = base ? [base, segment].join('.') : segment;
+    const part = base ? [base, segment].join('.') : segment;
     expanded.push(part);
     base = part;
   });


### PR DESCRIPTION
## What is it?

Replace the use of let with const for variables where the reference point never changes
## Why?

The proper use case for let is as a variable declaration where the data structure being referenced will change.  For example, when looping or doing math.  If you have code like:

```
let i = 0
i++
```

...then i is now referencing 1, instead of 0, and thus const could not be used.  Using const for variables whose reference point does not change ensures that accidental reference shifting can be caught with errors much faster, and also reinforces to the reader that the variable should not be reassigned.  Note that const does not create immutability, as any object it is referenced to will still be mutable.  For example:

```
const x = {}
x['someNewAttr'] = 'new value'
```

...will be allowed, as the object x is in reference to has not changed - only its internal values.
## How was it tested?

Ensured all existing tests will still pass with const vs let
