### PR TITLE
Accept strings as toggle values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -146,7 +146,7 @@ function isValidProps(props) {
 
 // If the selector is conditional, return it based on toggle
 function conditionalSelector(selector, toggle) {
-  const usingToggleHash = toggle != null && Object.keys(toggle).length !== 0;
+  const usingToggleHash = toggle != null && typeof toggle !== 'string' && Object.keys(toggle).length !== 0;
   const selectorParts = selector.split('?');
 
   // The selector is conditional

--- a/test/cairn.test.js
+++ b/test/cairn.test.js
@@ -125,6 +125,10 @@ describe('cairn', function () {
                 expect(style('thingOne thingTwo? thingTwo? parent?', false)).to.eql({ style: [thingOne] });
             });
 
+            it('should toggle true for string values', function () {
+              expect(style('thingOne thingTwo?', 'string')).to.eql({ style: [thingOne, thingTwo] });
+            });
+
             describe('selector hash', function () {
                 it('should use the class name as a default key in the toggle hash', function () {
                     expect(style('thingOne?', { thingOne: false })).to.eql({ style: [] });


### PR DESCRIPTION
I've got a use case where I'm passing a variable modifier as a prop, like so:

``` js
<Button
     onPress={this.login}
     text="Log In"
     modifier="inverse"
/>
```

Here's the stateless Button component, where I'm using a conditional to apply my modifier style ( `text.inverse` in this case) based on a toggle value:

``` js
const Button = ({ text, onPress, modifier }) => (
  <TouchableHighlight onPress={ onPress }>
    <Text { ...style('text text.'+ modifier +'?', modifier) }>
      { text }
    </Text>
  </TouchableHighlight>
);
```

When [Cairn tries to determine if I'm using a boolean or a hash](https://github.com/adamterlson/cairn/blob/033a13b02bb6958aa00df67bc255f3574fa0e816/lib/index.js#L149), string values are interpreted as hashes because they pass the `Object.keys(toggle).length !== 0` test. As a result, the returned selector is `undefined`.

I added a quick check here to filter out strings as eligible hashes.
