### PR TITLE
Fix support for `textShadowOffset` property

### DIFF
--- a/src/lib/pile.js
+++ b/src/lib/pile.js
@@ -31,7 +31,7 @@ export default function pile(prefix, sheet, flattened = {}, props = {}) {
 };
 
 // The property names which can be styled via an object in RN
-const STYLE_RESERVED_WORDS = ['shadowOffset', 'props'];
+const STYLE_RESERVED_WORDS = ['shadowOffset', 'textShadowOffset', 'props'];
 
 // Disallowed words in props definition
 const PROPS_RESERVED_WORDS = ['styles'];

--- a/test/cairn.test.js
+++ b/test/cairn.test.js
@@ -285,7 +285,8 @@ describe('cairn', function () {
 
                     problemChild: {
                         transform: [{ scale: 1 }],
-                        shadowOffset: { height: 1, width: 0 }
+                        shadowOffset: { height: 1, width: 0 },
+                        textShadowOffset: { height: 0, width: 1 }
                     }
                 }
             };
@@ -315,7 +316,8 @@ describe('cairn', function () {
                     },
                     'foo.parent.problemChild': {
                         transform: [{ scale: 1 }],
-                        shadowOffset: { height: 1, width: 0 }
+                        shadowOffset: { height: 1, width: 0 },
+                        textShadowOffset: { height: 0, width: 1 }
                     }
                 }
             })
@@ -345,7 +347,8 @@ describe('cairn', function () {
                     },
                     'parent.problemChild': {
                         transform: [{ scale: 1 }],
-                        shadowOffset: { height: 1, width: 0 }
+                        shadowOffset: { height: 1, width: 0 },
+                        textShadowOffset: { height: 0, width: 1 }
                     }
                 }
             })


### PR DESCRIPTION
[`textShadowOffset`](https://facebook.github.io/react-native/docs/text.html#style) was added as an object style property on `<Text>` elements in early 2016, but Cairn hasn't supported it.

I've been happily using Cairn on a number of projects and just bumped into this, so I'm hoping you'll take the patch. Tests included.