### PR TITLE
Remove duplicates of inline styles when using nested sheets

### DIFF
--- a/src/lib/factory.js
+++ b/src/lib/factory.js
@@ -34,15 +34,24 @@ function factory(parentStyler, sheet = {}, stylesTransformer, propsTransformer) 
 };
 
 function mergedStyle(...stylers) {
-  return function (...args) {
-    return stylers.reduce((prevStylesAndProps, styler) => {
-      const currentStylesAndProps = styler(...args);
+  return function (query, toggle, inline = []) {
+    if (Array.isArray(toggle)) {
+      inline = toggle;
+      toggle = null;
+    }
+
+    const props = stylers.reduce((prevStylesAndProps, styler) => {
+      const currentStylesAndProps = styler(query, toggle);
       return {
         ...prevStylesAndProps,
         ...currentStylesAndProps,
         style: [ ...prevStylesAndProps.style, ...currentStylesAndProps.style ]
       };
     }, { style: [] });
+
+    props.style = [...props.style, ...inline];
+
+    return props;
   }
 }
 

--- a/src/lib/style.js
+++ b/src/lib/style.js
@@ -1,10 +1,5 @@
 export default function style(sheet) {
-  return function styler(query, toggle, inline = []) {
-    if (Array.isArray(toggle)) {
-      inline = toggle;
-      toggle = null;
-    }
-
+  return function styler(query, toggle) {
     const missing = [];
     const parts = query.split(' ');
     const selectors = parts
@@ -38,8 +33,6 @@ export default function style(sheet) {
 
         return Object.assign(props, sheet.props[selector]);
       }, {});
-
-    style = [...style, ...inline];
 
     props.style = style;
 

--- a/test/cairn.test.js
+++ b/test/cairn.test.js
@@ -501,9 +501,15 @@ describe('cairn', function () {
                 expect(style('foo.bar').newprop).to.eql('extendedvalue');
             });
 
-            it('should extned style attributes', function () {
+            it('should extend style attributes', function () {
                 expect(style('bar').style).to.eql([{ height: 20 }, { width: 20 }]);
                 expect(style('foo.bar').style).to.eql([{ height: 15 }, { height: 10 }, { width: 15 }, { width: 10 }]);
+            });
+
+            it('should append on the array of inline styles at the end', function () {
+                let inline1 = { color: 'red' };
+                let inline2 = { color: 'blue' };
+                expect(style('bar', [inline1, inline2]).style).to.eql([{ height: 20 }, { width: 20 }, inline1, inline2]);
             });
         });
 


### PR DESCRIPTION
Prior to this change, a series of nested stylers would duplicate the inline styles after each application.

This is best explained by example:

```javascript
const base = cairn({
  foo: {color: 'red'},
});

const style = base.extend({
  bar: {backgroundColor: 'blue'}
});

style('foo bar', [{fontSize: 10}]).style
// should be [{color: 'red'}, {backgroundColor: 'blue'}, {fontSize: 10}]
// is errantly [{color: 'red'}, {fontSize: 10}, {backgroundColor: 'blue'}, {fontSize: 10}]
```

This PR fixes the problem and adds a test. It moves the inline style logic from `style.js` over to `factory.js`, but since `factory.js` is responsible for composing the stylers, this seems okay.