### PR TITLE
Add caching for selectors without inline styles

### DIFF
--- a/src/lib/style.js
+++ b/src/lib/style.js
@@ -1,20 +1,7 @@
 export default function style(sheet) {
   return function styler(query, toggle) {
     const missing = [];
-    const parts = query.split(' ');
-    const selectors = parts
-      .reduce((arr, selector) => {
-        // Add conditional selector support
-        selector = conditionalSelector(selector, toggle);
-
-        if (!selector) return arr;
-        
-        // Expand out dot notation syntax
-        arr = arr.concat(dotExpander(selector));
-
-        return arr;
-      }, []);
-
+    const selectors = selectorsFor(query, toggle);
     // Compile styles
     let style = selectors
       .map(selector => {
@@ -39,6 +26,37 @@ export default function style(sheet) {
     return props;
   };
 };
+
+function selectorsFor(query, toggle) {
+  const parts = query.split(' ');
+  const selectors = parts
+    .reduce((arr, selector) => {
+      // Add conditional selector support
+      selector = conditionalSelector(selector, toggle);
+
+      if (!selector) return arr;
+
+      // Expand out dot notation syntax
+      arr = arr.concat(dotExpander(selector));
+
+      return arr;
+    }, []);
+
+  return selectors;
+}
+
+export function cacheKey(query, toggle, inline = []) {
+  if (Array.isArray(toggle)) {
+    inline = toggle;
+    toggle = null;
+  }
+
+  if (inline.length) {
+    return null;
+  }
+
+  return selectorsFor(query, toggle).join(' ');
+}
 
 // If the selector is conditional, return it based on toggle
 function conditionalSelector(selector, toggle) {

--- a/test/cairn.test.js
+++ b/test/cairn.test.js
@@ -167,6 +167,16 @@ describe('cairn', function () {
             });
         });
 
+        describe('selector cache', function () {
+            it('should return the same array reference for the same simple selectors', function () {
+                expect(style('thingOne thingTwo').style).to.equal(style('thingOne thingTwo').style);
+            });
+
+            it('should return the same array reference for the same optional selector activations', function () {
+                expect(style('thingOne thingTwo? thingTwo? parent?', false).style).to.equal(style('thingOne thingTwo? thingTwo? parent?', false).style);
+            });
+        });
+
         describe('bad selectors', function () {
             it('should remove undefined selector result from array', function () {
                 expect(style('thingOne invalid thingTwo')).to.eql({ style: [thingOne, thingTwo] });


### PR DESCRIPTION
This helps to preserve referential equality, which is essential for avoiding unnecessary rerendering of pure components. (We only cache if there are no inline styles.)