### PR TITLE
Avoid calling Object.keys on non-object

### DIFF
--- a/src/lib/style.js
+++ b/src/lib/style.js
@@ -60,7 +60,7 @@ export function cacheKey(query, toggle, inline = []) {
 
 // If the selector is conditional, return it based on toggle
 function conditionalSelector(selector, toggle) {
-  const usingToggleHash = toggle != null && typeof toggle !== 'string' && Object.keys(toggle).length !== 0;
+  const usingToggleHash = toggle != null && typeof toggle === 'object' && Object.keys(toggle).length !== 0;
   const selectorParts = selector.split('?');
 
   // The selector is conditional


### PR DESCRIPTION
According to the spec for `Object.keys`, this throws for non-objects (and is doing so on Android's JS VM).